### PR TITLE
Possibility to move or copy to multiple keys in LocalizationProvider

### DIFF
--- a/Source/Localization/LocalizationProvider.swift
+++ b/Source/Localization/LocalizationProvider.swift
@@ -256,11 +256,15 @@ fileprivate extension LocalizationProvider {
                 newTable[key] = value
             case .erase:
                 break
-            case .moveTo(let newKey):
-                newTable[newKey] = value
-            case .copyTo(let newKey):
+            case .moveTo(let newKeys):
+                for newKey in newKeys {
+                    newTable[newKey] = value
+                }
+            case .copyTo(let newKeys):
                 newTable[key] = value
-                newTable[newKey] = value
+                for newKey in newKeys {
+                    newTable[newKey] = value
+                }
             }
         }
         return newTable

--- a/Source/Localization/LocalizationTransformation.swift
+++ b/Source/Localization/LocalizationTransformation.swift
@@ -46,8 +46,8 @@ public enum LocalizationTransformationOperation {
     case keep
     /// Localized string will be removed from final string table.
     case erase
-    /// Localized string will be stored under the new key, provided as case parameter.
-    case moveTo(key: String)
-    /// Localized string will be stored under the original and also the new key, provided as case parameter.
-    case copyTo(key: String)
+    /// Localized string will be stored under new keys, provided as case parameter.
+    case moveTo(keys: [String])
+    /// Localized string will be stored under the original and also new keys, provided as case parameter.
+    case copyTo(keys: [String])
 }


### PR DESCRIPTION
Needed to avoid unnecessary key duplication in cases when the same string is used in different scenarios. This will come very handy with new features of `swift-lime-auth`.